### PR TITLE
feat: GS v 0 raster bitmap rendering + codepage support

### DIFF
--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -69,7 +69,7 @@ impl EmulatorState {
             emphasis: self.printer_state.emphasis,
             underline: self.printer_state.underline,
             italic: self.printer_state.italic,
-            buffer_lines: self.printer_state.buffer.len(),
+            buffer_lines: self.printer_state.get_buffer().len(),
             command_count: self.command_history.len(),
             dpi: self.printer_state.dpi,
         }

--- a/src/escpos/commands.rs
+++ b/src/escpos/commands.rs
@@ -2,31 +2,36 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EscPosCommand {
-    // Commandes de base
+    // Basic commands
     Text(String),
     NewLine,
     LineFeed,
     CarriageReturn,
-    
-    // Commandes de police
+
+    // Font commands
     SetFont(Font),
     SetFontSize(u32),
-    
-    // Commandes de formatage
+
+    // Formatting commands
     SetJustification(Justification),
     SetEmphasis(bool),
     SetUnderline(bool),
     SetItalic(bool),
     SetLineHeight(u32),
-    
-    // Commandes d'impression
+
+    // Print commands
     CutPaper,
     PrintImage(Vec<u8>),
-    
-    // Commandes de contrôle
+    /// Raster bitmap with width (bytes per row) and height (rows)
+    PrintRasterImage { width_bytes: u16, height: u16, data: Vec<u8> },
+
+    // Codepage selection (ESC t n)
+    SetCodepage(u8),
+
+    // Control commands
     InitializePrinter,
-    
-    // Commandes inconnues
+
+    // Unknown commands
     Unknown(Vec<u8>),
 }
 

--- a/src/escpos/parser.rs
+++ b/src/escpos/parser.rs
@@ -19,7 +19,6 @@ impl EscPosParser {
 
         while i < self.buffer.len() {
             match self.buffer[i] {
-                // Commandes de base
                 b'\n' => {
                     commands.push(EscPosCommand::NewLine);
                     i += 1;
@@ -28,22 +27,43 @@ impl EscPosParser {
                     commands.push(EscPosCommand::CarriageReturn);
                     i += 1;
                 }
-                b'\x1B' => {
-                    // Séquence ESC
-                    if i + 1 < self.buffer.len() {
-                        let command = self.parse_esc_command(&self.buffer[i..])?;
-                        if let Some(cmd) = command {
+                0x1B => {
+                    // ESC sequence
+                    if i + 1 >= self.buffer.len() {
+                        break; // Wait for more data
+                    }
+                    match self.parse_esc_command(&self.buffer[i..]) {
+                        Ok(Some((cmd, consumed))) => {
                             commands.push(cmd);
+                            i += consumed;
                         }
-                        i += 2; // ESC + commande
-                    } else {
-                        break; // Attendre plus de données
+                        Ok(None) => break, // Incomplete, wait for more
+                        Err(_) => { i += 2; } // Skip bad ESC sequence
+                    }
+                }
+                0x1D => {
+                    // GS sequence
+                    if i + 1 >= self.buffer.len() {
+                        break;
+                    }
+                    match self.parse_gs_command(&self.buffer[i..]) {
+                        Ok(Some((cmd, consumed))) => {
+                            commands.push(cmd);
+                            i += consumed;
+                        }
+                        Ok(None) => break,
+                        Err(_) => { i += 2; }
                     }
                 }
                 _ => {
-                    // Texte normal
+                    // Normal text bytes
                     let text_start = i;
-                    while i < self.buffer.len() && self.buffer[i] != b'\x1B' && self.buffer[i] != b'\n' && self.buffer[i] != b'\r' {
+                    while i < self.buffer.len()
+                        && self.buffer[i] != 0x1B
+                        && self.buffer[i] != 0x1D
+                        && self.buffer[i] != b'\n'
+                        && self.buffer[i] != b'\r'
+                    {
                         i += 1;
                     }
                     if i > text_start {
@@ -56,7 +76,6 @@ impl EscPosParser {
             }
         }
 
-        // Nettoyer le buffer des données traitées
         if i > 0 {
             self.buffer.drain(0..i);
         }
@@ -64,117 +83,147 @@ impl EscPosParser {
         Ok(commands)
     }
 
-    fn parse_esc_command(&self, data: &[u8]) -> Result<Option<EscPosCommand>> {
+    /// Parse ESC (0x1B) commands. Returns (command, bytes_consumed).
+    fn parse_esc_command(&self, data: &[u8]) -> Result<Option<(EscPosCommand, usize)>> {
         if data.len() < 2 {
             return Ok(None);
         }
 
         match data[1] {
-            // Initialisation de l'imprimante
-            b'@' => Ok(Some(EscPosCommand::InitializePrinter)),
+            // Initialize printer
+            b'@' => Ok(Some((EscPosCommand::InitializePrinter, 2))),
 
-            // Sélection de la police
+            // Select font
             b'M' => {
-                if data.len() >= 3 {
-                    let font = match data[2] {
-                        0 => Font::FontA,
-                        1 => Font::FontB,
-                        2 => Font::FontC,
-                        _ => Font::FontA,
-                    };
-                    Ok(Some(EscPosCommand::SetFont(font)))
-                } else {
-                    Ok(Some(EscPosCommand::SetFont(Font::FontA)))
-                }
+                if data.len() < 3 { return Ok(None); }
+                let font = match data[2] {
+                    0 => Font::FontA,
+                    1 => Font::FontB,
+                    2 => Font::FontC,
+                    _ => Font::FontA,
+                };
+                Ok(Some((EscPosCommand::SetFont(font), 3)))
             }
 
             // Justification
             b'a' => {
-                if data.len() >= 3 {
-                    let justification = match data[2] {
-                        0 => Justification::Left,
-                        1 => Justification::Center,
-                        2 => Justification::Right,
-                        _ => Justification::Left,
-                    };
-                    Ok(Some(EscPosCommand::SetJustification(justification)))
-                } else {
-                    Ok(Some(EscPosCommand::SetJustification(Justification::Left)))
-                }
+                if data.len() < 3 { return Ok(None); }
+                let j = match data[2] {
+                    0 => Justification::Left,
+                    1 => Justification::Center,
+                    2 => Justification::Right,
+                    _ => Justification::Left,
+                };
+                Ok(Some((EscPosCommand::SetJustification(j), 3)))
             }
 
-            // Emphase
-            b'E' => Ok(Some(EscPosCommand::SetEmphasis(true))),
-            b'F' => Ok(Some(EscPosCommand::SetEmphasis(false))),
+            // Emphasis on/off
+            b'E' => Ok(Some((EscPosCommand::SetEmphasis(true), 2))),
+            b'F' => Ok(Some((EscPosCommand::SetEmphasis(false), 2))),
 
-            // Soulignement
+            // Underline
             b'-' => {
-                if data.len() >= 3 {
-                    let underline = data[2];
-                    Ok(Some(EscPosCommand::SetUnderline(underline != 0)))
-                } else {
-                    Ok(Some(EscPosCommand::SetUnderline(false)))
-                }
+                if data.len() < 3 { return Ok(None); }
+                Ok(Some((EscPosCommand::SetUnderline(data[2] != 0), 3)))
             }
 
-            // Italique
-            b'4' => Ok(Some(EscPosCommand::SetItalic(true))),
-            b'5' => Ok(Some(EscPosCommand::SetItalic(false))),
+            // Italic on/off
+            b'4' => Ok(Some((EscPosCommand::SetItalic(true), 2))),
+            b'5' => Ok(Some((EscPosCommand::SetItalic(false), 2))),
 
-            // Hauteur de ligne
+            // Line height
             b'3' => {
-                if data.len() >= 3 {
-                    let height = data[2] as u32;
-                    Ok(Some(EscPosCommand::SetLineHeight(height)))
-                } else {
-                    Ok(Some(EscPosCommand::SetLineHeight(24)))
-                }
+                if data.len() < 3 { return Ok(None); }
+                Ok(Some((EscPosCommand::SetLineHeight(data[2] as u32), 3)))
             }
 
-            // Taille de police
+            // Font size / print mode
             b'!' => {
-                if data.len() >= 3 {
-                    let size = data[2] as u32;
-                    Ok(Some(EscPosCommand::SetFontSize(size)))
-                } else {
-                    Ok(Some(EscPosCommand::SetFontSize(12)))
-                }
+                if data.len() < 3 { return Ok(None); }
+                Ok(Some((EscPosCommand::SetFontSize(data[2] as u32), 3)))
             }
 
-            // Coupe du papier
-            b'm' => Ok(Some(EscPosCommand::CutPaper)),
-            b'i' => Ok(Some(EscPosCommand::CutPaper)),
+            // Codepage selection (ESC t n)
+            b't' => {
+                if data.len() < 3 { return Ok(None); }
+                Ok(Some((EscPosCommand::SetCodepage(data[2]), 3)))
+            }
 
-            // Alimentation du papier
+            // Cut paper
+            b'm' | b'i' => Ok(Some((EscPosCommand::CutPaper, 2))),
+
+            // Paper feed
             b'J' => {
-                if data.len() >= 3 {
-                    let _units = data[2] as u32;
-                    Ok(Some(EscPosCommand::LineFeed))
-                } else {
-                    Ok(Some(EscPosCommand::LineFeed))
-                }
+                if data.len() < 3 { return Ok(None); }
+                Ok(Some((EscPosCommand::LineFeed, 3)))
             }
 
-            // Image raster (simplifié)
+            // Bit image (ESC *) — simplified
             b'*' => {
-                if data.len() >= 6 {
-                    let width = ((data[2] as u16) << 8) | (data[3] as u16);
-                    let height = ((data[4] as u16) << 8) | (data[5] as u16);
-                    let image_data = if data.len() >= 6 + (width * height / 8) as usize {
-                        data[6..6 + (width * height / 8) as usize].to_vec()
-                    } else {
-                        vec![]
-                    };
-                    Ok(Some(EscPosCommand::PrintImage(image_data)))
-                } else {
-                    Ok(Some(EscPosCommand::PrintImage(vec![])))
+                if data.len() < 4 { return Ok(None); }
+                let m = data[2];
+                let nl = data[3] as u16;
+                if data.len() < 5 { return Ok(None); }
+                let nh = data[4] as u16;
+                let n_dots = nl + nh * 256;
+                let bytes_per_col: u16 = match m { 0 | 1 => 1, 32 | 33 => 3, _ => 1 };
+                let total = bytes_per_col as usize * n_dots as usize;
+                let consumed = 5 + total;
+                if data.len() < consumed { return Ok(None); }
+                let image_data = data[5..consumed].to_vec();
+                Ok(Some((EscPosCommand::PrintImage(image_data), consumed)))
+            }
+
+            _ => {
+                Ok(Some((EscPosCommand::Unknown(data[..2].to_vec()), 2)))
+            }
+        }
+    }
+
+    /// Parse GS (0x1D) commands. Returns (command, bytes_consumed).
+    fn parse_gs_command(&self, data: &[u8]) -> Result<Option<(EscPosCommand, usize)>> {
+        if data.len() < 2 {
+            return Ok(None);
+        }
+
+        match data[1] {
+            // GS v 0 — Print raster bit image
+            b'v' => {
+                if data.len() < 8 { return Ok(None); }
+                // GS v 0 m xL xH yL yH d1...dk
+                let _mode = data[3]; // 0=normal, 1=double-width, 2=double-height, 3=both
+                let x_l = data[4] as u16;
+                let x_h = data[5] as u16;
+                let y_l = data[6] as u16;
+                let y_h = data[7] as u16;
+                let width_bytes = x_l + x_h * 256; // bytes per row
+                let height = y_l + y_h * 256;       // number of rows
+                let total = width_bytes as usize * height as usize;
+                let consumed = 8 + total;
+                if data.len() < consumed { return Ok(None); }
+                let image_data = data[8..consumed].to_vec();
+                Ok(Some((
+                    EscPosCommand::PrintRasterImage { width_bytes, height, data: image_data },
+                    consumed,
+                )))
+            }
+
+            // GS V — Cut paper (with variants)
+            b'V' => {
+                if data.len() < 3 { return Ok(None); }
+                match data[2] {
+                    0 | 1 => Ok(Some((EscPosCommand::CutPaper, 3))),
+                    65 | 66 => {
+                        // GS V 65/66 n — need one more byte
+                        if data.len() < 4 { return Ok(None); }
+                        Ok(Some((EscPosCommand::CutPaper, 4)))
+                    }
+                    _ => Ok(Some((EscPosCommand::CutPaper, 3))),
                 }
             }
 
-            // Commande inconnue
             _ => {
-                let unknown_data = data.to_vec();
-                Ok(Some(EscPosCommand::Unknown(unknown_data)))
+                Ok(Some((EscPosCommand::Unknown(data[..2].to_vec()), 2)))
             }
         }
     }

--- a/src/escpos/printer.rs
+++ b/src/escpos/printer.rs
@@ -17,17 +17,25 @@ impl PaperWidth {
             PaperWidth::Width80mm => 640,
         }
     }
-    
+
     pub fn get_max_chars(&self, font_size: u32) -> u32 {
         let dots = self.get_width_dots();
-        // Calculer le nombre max de caractères selon la taille de police
         match font_size {
-            8..=12 => dots / 8,   // Police normale
-            13..=16 => dots / 10, // Police moyenne
-            17..=24 => dots / 12, // Police grande
-            _ => dots / 8,        // Par défaut
+            8..=12 => dots / 8,
+            13..=16 => dots / 10,
+            17..=24 => dots / 12,
+            _ => dots / 8,
         }
     }
+}
+
+/// A single line element in the receipt buffer
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ReceiptLine {
+    Text(String),
+    /// Monochrome bitmap: width in pixels, height in pixels, 1-bit-per-pixel packed data
+    Bitmap { width_px: u32, height_px: u32, data: Vec<u8> },
+    Separator,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -38,10 +46,11 @@ pub struct PrinterState {
     pub emphasis: bool,
     pub underline: bool,
     pub italic: bool,
-    pub buffer: Vec<String>,
+    pub buffer: Vec<ReceiptLine>,
     pub line_height: u32,
     pub font_size: u32,
     pub dpi: u32,
+    pub codepage: u8,
 }
 
 impl PrinterState {
@@ -57,6 +66,7 @@ impl PrinterState {
             line_height: 24,
             font_size: 12,
             dpi: 180,
+            codepage: 0,
         }
     }
 
@@ -84,12 +94,24 @@ impl PrinterState {
                 self.italic = *enabled;
             }
             EscPosCommand::CutPaper => {
-                // Simuler la coupe du papier
                 self.add_separator();
             }
             EscPosCommand::PrintImage(_image_data) => {
-                // TODO: Implémenter l'affichage d'image
-                self.add_text("[IMAGE]");
+                // ESC * bit image — store as text placeholder for now
+                self.add_text("[BIT IMAGE]");
+            }
+            EscPosCommand::PrintRasterImage { width_bytes, height, data } => {
+                // GS v 0 raster image — width_bytes is bytes per row, each byte = 8 pixels
+                let width_px = *width_bytes as u32 * 8;
+                let height_px = *height as u32;
+                self.buffer.push(ReceiptLine::Bitmap {
+                    width_px,
+                    height_px,
+                    data: data.clone(),
+                });
+            }
+            EscPosCommand::SetCodepage(cp) => {
+                self.codepage = *cp;
             }
             EscPosCommand::SetLineHeight(height) => {
                 self.line_height = *height;
@@ -97,48 +119,42 @@ impl PrinterState {
             EscPosCommand::SetFontSize(size) => {
                 self.font_size = *size;
             }
-            EscPosCommand::Unknown(_) => {
-                // Ignorer les commandes inconnues
-            }
-            _ => {
-                // Ignorer les autres commandes
-            }
+            EscPosCommand::Unknown(_) => {}
+            _ => {}
         }
     }
 
     fn add_text(&mut self, text: &str) {
-        if let Some(last_line) = self.buffer.last_mut() {
-            // Vérifier si le texte dépasse la largeur du papier
+        if let Some(ReceiptLine::Text(last_line)) = self.buffer.last_mut() {
             let max_chars = self.paper_width.get_max_chars(self.font_size);
             let current_length = last_line.chars().count();
-            
+
             if current_length + text.chars().count() > max_chars as usize {
-                // Le texte dépasse, créer une nouvelle ligne
                 self.add_new_line();
-                self.buffer.last_mut().unwrap().push_str(text);
+                if let Some(ReceiptLine::Text(new_line)) = self.buffer.last_mut() {
+                    new_line.push_str(text);
+                }
             } else {
                 last_line.push_str(text);
             }
         } else {
-            self.buffer.push(text.to_string());
+            self.buffer.push(ReceiptLine::Text(text.to_string()));
         }
     }
 
     fn add_new_line(&mut self) {
-        self.buffer.push(String::new());
+        self.buffer.push(ReceiptLine::Text(String::new()));
     }
 
     fn add_separator(&mut self) {
-        let max_chars = self.paper_width.get_max_chars(self.font_size);
-        let separator = "-".repeat(max_chars as usize);
-        self.buffer.push(separator);
+        self.buffer.push(ReceiptLine::Separator);
     }
 
     pub fn clear_buffer(&mut self) {
         self.buffer.clear();
     }
 
-    pub fn get_buffer(&self) -> &[String] {
+    pub fn get_buffer(&self) -> &[ReceiptLine] {
         &self.buffer
     }
 
@@ -147,44 +163,57 @@ impl PrinterState {
     }
 
     pub fn get_printing_width_dots(&self) -> u32 {
-        // Largeur d'impression = largeur du papier - marges
         let dots = self.paper_width.get_width_dots();
-        dots.saturating_sub(30) // 8mm = ~30 dots de marges
+        dots.saturating_sub(30)
     }
 
-    pub fn render_receipt(&self) -> RgbImage {
-        let width = self.get_paper_width_dots() as u32;
-        let height = self.calculate_total_height();
-        
-        let mut image = ImageBuffer::new(width, height);
-        
-        // Remplir avec du blanc
+    /// Convert a monochrome 1bpp bitmap to an RGB image for display
+    pub fn bitmap_to_rgb(width_px: u32, height_px: u32, data: &[u8]) -> RgbImage {
+        let mut image = ImageBuffer::new(width_px, height_px);
+        // Fill white
         for pixel in image.pixels_mut() {
             *pixel = Rgb([255, 255, 255]);
         }
-        
-        // Rendu du texte (simplifié)
-        let mut y_offset = 0;
-        for line in &self.buffer {
-            if !line.is_empty() {
-                self.render_text_line(&mut image, line, y_offset);
+
+        let bytes_per_row = (width_px + 7) / 8;
+        for y in 0..height_px {
+            for x in 0..width_px {
+                let byte_idx = (y * bytes_per_row + x / 8) as usize;
+                let bit_idx = 7 - (x % 8);
+                if byte_idx < data.len() {
+                    if (data[byte_idx] >> bit_idx) & 1 == 1 {
+                        image.put_pixel(x, y, Rgb([0, 0, 0])); // Black pixel
+                    }
+                }
             }
-            y_offset += self.line_height;
         }
-        
         image
     }
 
-    fn render_text_line(&self, _image: &mut RgbImage, _text: &str, _y_offset: u32) {
-        // TODO: Implémenter le rendu du texte
-        // Pour l'instant, c'est juste un placeholder
+    pub fn render_receipt(&self) -> RgbImage {
+        let width = self.get_paper_width_dots();
+        let height = self.calculate_total_height();
+
+        let mut image = ImageBuffer::new(width, height);
+        for pixel in image.pixels_mut() {
+            *pixel = Rgb([255, 255, 255]);
+        }
+
+        image
     }
 
     pub fn calculate_total_height(&self) -> u32 {
-        self.buffer.len() as u32 * self.line_height
+        let mut h = 0u32;
+        for line in &self.buffer {
+            match line {
+                ReceiptLine::Text(_) => h += self.line_height,
+                ReceiptLine::Bitmap { height_px, .. } => h += height_px,
+                ReceiptLine::Separator => h += self.line_height,
+            }
+        }
+        h.max(1)
     }
 
-    // Nouvelles méthodes pour les paramètres
     pub fn set_paper_width(&mut self, width: PaperWidth) {
         self.paper_width = width;
     }

--- a/src/gui/command_log.rs
+++ b/src/gui/command_log.rs
@@ -147,7 +147,13 @@ impl CommandLog {
                     "✂️ Paper cut".to_string()
                 }
                 crate::escpos::commands::EscPosCommand::PrintImage(_) => {
-                    "🖼️ Image".to_string()
+                    "🖼️ Bit Image (ESC *)".to_string()
+                }
+                crate::escpos::commands::EscPosCommand::PrintRasterImage { width_bytes, height, .. } => {
+                    format!("🖼️ Raster Image (GS v 0) {}×{}", width_bytes * 8, height)
+                }
+                crate::escpos::commands::EscPosCommand::SetCodepage(cp) => {
+                    format!("🌐 Codepage: {}", cp)
                 }
                 crate::escpos::commands::EscPosCommand::SetLineHeight(height) => {
                     format!("📏 Line height: {}", height)

--- a/src/gui/receipt_viewer.rs
+++ b/src/gui/receipt_viewer.rs
@@ -1,11 +1,15 @@
 use crate::emulator::EmulatorState;
-use egui::{ScrollArea, Ui};
+use crate::escpos::printer::{PrinterState, ReceiptLine};
+use egui::{ColorImage, ScrollArea, TextureHandle, TextureOptions, Ui};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 pub struct ReceiptViewer {
     show_paper_edges: bool,
     show_grid: bool,
+    /// Cache of rendered bitmap textures (keyed by data hash)
+    bitmap_cache: HashMap<u64, TextureHandle>,
 }
 
 impl Default for ReceiptViewer {
@@ -13,8 +17,19 @@ impl Default for ReceiptViewer {
         Self {
             show_paper_edges: true,
             show_grid: false,
+            bitmap_cache: HashMap::new(),
         }
     }
+}
+
+fn hash_bytes(data: &[u8]) -> u64 {
+    // Simple FNV-1a hash for cache key
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for &byte in data {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
 }
 
 impl ReceiptViewer {
@@ -30,11 +45,12 @@ impl ReceiptViewer {
         ui.horizontal(|ui| {
             ui.checkbox(&mut self.show_paper_edges, "Show paper edges");
             ui.checkbox(&mut self.show_grid, "Show grid");
-            
+
             if ui.button("🗑️ Clear").clicked() {
                 if let Ok(mut state) = emulator_state.try_lock() {
                     state.clear_printer_buffer();
                 }
+                self.bitmap_cache.clear();
             }
         });
 
@@ -50,10 +66,10 @@ impl ReceiptViewer {
         });
     }
 
-    fn render_receipt(&self, ui: &mut Ui, state: &EmulatorState) {
+    fn render_receipt(&mut self, ui: &mut Ui, state: &EmulatorState) {
         let printer_state = state.get_printer_state();
         let buffer = printer_state.get_buffer();
-        
+
         if buffer.is_empty() {
             ui.centered_and_justified(|ui| {
                 ui.label("No receipt data available");
@@ -64,28 +80,50 @@ impl ReceiptViewer {
 
         // Paper simulation
         let paper_width = printer_state.get_paper_width_dots();
-        let _max_width = (paper_width as f32 * 0.5) as f32; // Scale down for display
-        
+        let max_chars = printer_state.paper_width.get_max_chars(printer_state.font_size);
+
         ui.group(|ui| {
             // Paper header
             ui.horizontal(|ui| {
                 ui.label(format!("📄 Paper: {:?}", printer_state.paper_width));
                 ui.label(format!("🔤 Font: {:?}", printer_state.current_font));
                 ui.label(format!("📐 Align: {:?}", printer_state.justification));
+                if printer_state.codepage != 0 {
+                    ui.label(format!("🌐 CP: {}", printer_state.codepage));
+                }
             });
 
             ui.separator();
 
             // Receipt content
             for (line_num, line) in buffer.iter().enumerate() {
-                if !line.is_empty() {
-                    ui.horizontal(|ui| {
-                        ui.label(format!("{:03}", line_num + 1));
-                        ui.label("│");
-                        ui.label(line);
-                    });
-                } else {
-                    ui.label(""); // Empty line
+                match line {
+                    ReceiptLine::Text(text) => {
+                        if !text.is_empty() {
+                            ui.horizontal(|ui| {
+                                ui.label(format!("{:03}", line_num + 1));
+                                ui.label("│");
+                                if printer_state.emphasis {
+                                    ui.strong(text);
+                                } else {
+                                    ui.monospace(text);
+                                }
+                            });
+                        } else {
+                            ui.label("");
+                        }
+                    }
+                    ReceiptLine::Bitmap { width_px, height_px, data } => {
+                        self.render_bitmap(ui, *width_px, *height_px, data, paper_width);
+                    }
+                    ReceiptLine::Separator => {
+                        let sep = "─".repeat(max_chars as usize);
+                        ui.horizontal(|ui| {
+                            ui.label(format!("{:03}", line_num + 1));
+                            ui.label("│");
+                            ui.label(&sep);
+                        });
+                    }
                 }
             }
 
@@ -93,5 +131,30 @@ impl ReceiptViewer {
             ui.separator();
             ui.label("✂️ Cut line");
         });
+    }
+
+    fn render_bitmap(&mut self, ui: &mut Ui, width_px: u32, height_px: u32, data: &[u8], _paper_width: u32) {
+        let cache_key = hash_bytes(data);
+
+        // Get or create texture
+        let texture = self.bitmap_cache.entry(cache_key).or_insert_with(|| {
+            let rgb_image = PrinterState::bitmap_to_rgb(width_px, height_px, data);
+            let size = [rgb_image.width() as usize, rgb_image.height() as usize];
+            let pixels: Vec<egui::Color32> = rgb_image
+                .pixels()
+                .map(|p| egui::Color32::from_rgb(p[0], p[1], p[2]))
+                .collect();
+            let color_image = ColorImage { size, pixels };
+            ui.ctx().load_texture(
+                format!("bitmap_{}", cache_key),
+                color_image,
+                TextureOptions::NEAREST,
+            )
+        });
+
+        // Scale down to fit receipt viewer — max display width ~400px
+        let scale = (400.0 / width_px as f32).min(1.0);
+        let display_size = egui::vec2(width_px as f32 * scale, height_px as f32 * scale);
+        ui.image((texture.id(), display_size));
     }
 }


### PR DESCRIPTION
## Summary

- **GS v 0 raster image parsing** — correctly extracts width (bytes per row), height, and pixel data from the `GS v 0` command used by most ESC/POS libraries for bitmap printing
- **Bitmap rendering in receipt viewer** — converts monochrome 1bpp data to RGB images and displays them as egui textures with caching
- **ESC t codepage selection** — parses the codepage command and displays it in the viewer header
- **ESC * bit image fix** — correct mode/dots calculation for the existing bit image command
- **GS V cut paper** — handles all cut paper variants (0, 1, 65, 66)
- **GS (0x1D) command prefix** — the parser now handles GS commands alongside ESC commands

## Motivation

Many POS applications render Arabic/CJK/RTL text as monochrome bitmaps client-side (since most thermal printers lack Arabic ROM fonts) and send them via `GS v 0`. Without this change, all bitmap content shows as `[IMAGE]` placeholder text.

## Test plan

- [x] Build passes (`cargo build --release`)
- [ ] Print a receipt with bitmap content (Arabic text rendered as GS v 0) — should display as actual image in the receipt viewer
- [ ] Print a receipt with plain ASCII text — no regression
- [ ] Paper cut commands still work (both ESC and GS variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)