### PR TITLE
feat: add serial/COM port listener for ESC/POS input

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
+serialport = "4"
 
 [profile.release]
 opt-level = 3

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -1,5 +1,6 @@
 use crate::emulator::EmulatorState;
 use crate::gui::{CommandLog, ReceiptViewer, SettingsPanel};
+use crate::networking::serial::SerialHandle;
 use eframe::egui::{CentralPanel, TopBottomPanel};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -17,29 +18,27 @@ impl Default for Tab {
 
 pub struct EscPosEmulatorApp {
     pub emulator_state: std::sync::Arc<tokio::sync::Mutex<EmulatorState>>,
+    tokio_handle: tokio::runtime::Handle,
     selected_tab: Tab,
     receipt_viewer: ReceiptViewer,
     command_log: CommandLog,
     settings_panel: SettingsPanel,
+    serial_handle: Option<SerialHandle>,
 }
 
-impl Default for EscPosEmulatorApp {
-    fn default() -> Self {
+impl EscPosEmulatorApp {
+    pub fn new(
+        emulator_state: std::sync::Arc<tokio::sync::Mutex<EmulatorState>>,
+        tokio_handle: tokio::runtime::Handle,
+    ) -> Self {
         Self {
-            emulator_state: std::sync::Arc::new(tokio::sync::Mutex::new(EmulatorState::new())),
+            emulator_state,
+            tokio_handle,
             selected_tab: Tab::Receipt,
             receipt_viewer: ReceiptViewer::new(),
             command_log: CommandLog::new(),
             settings_panel: SettingsPanel::default(),
-        }
-    }
-}
-
-impl EscPosEmulatorApp {
-    pub fn new(emulator_state: std::sync::Arc<tokio::sync::Mutex<EmulatorState>>) -> Self {
-        Self {
-            emulator_state,
-            ..Default::default()
+            serial_handle: None,
         }
     }
 }
@@ -52,7 +51,6 @@ impl eframe::App for EscPosEmulatorApp {
 
 impl EscPosEmulatorApp {
     fn show(&mut self, ctx: &eframe::egui::Context) {
-        // Top panel with tabs
         TopBottomPanel::top("tabs").show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.selectable_value(&mut self.selected_tab, Tab::Receipt, "🖨️ Receipt");
@@ -61,7 +59,6 @@ impl EscPosEmulatorApp {
             });
         });
 
-        // Central panel with content
         CentralPanel::default().show(ctx, |ui| {
             match self.selected_tab {
                 Tab::Receipt => {
@@ -71,9 +68,12 @@ impl EscPosEmulatorApp {
                     self.command_log.show(ui, &self.emulator_state);
                 }
                 Tab::Settings => {
-                    if let Ok(mut state) = self.emulator_state.try_lock() {
-                        self.settings_panel.show(ui, &mut state);
-                    }
+                    self.settings_panel.show(
+                        ui,
+                        &mut self.serial_handle,
+                        &self.emulator_state,
+                        &self.tokio_handle,
+                    );
                 }
             }
         });

--- a/src/gui/settings_panel.rs
+++ b/src/gui/settings_panel.rs
@@ -1,44 +1,62 @@
 use crate::emulator::EmulatorState;
+use crate::networking::serial::{list_com_ports, start_serial_listener, SerialHandle};
 use egui::Ui;
 use std::process::Command;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 pub struct SettingsPanel {
-    // No more useless settings - the emulator works according to ESC/POS standards
+    available_ports: Vec<String>,
+    selected_port_idx: usize,
+    baud_rates: Vec<u32>,
+    selected_baud_idx: usize,
+    status_message: String,
 }
 
 impl Default for SettingsPanel {
     fn default() -> Self {
-        Self {}
+        Self {
+            available_ports: list_com_ports(),
+            selected_port_idx: 0,
+            baud_rates: vec![9600, 19200, 38400, 57600, 115200],
+            selected_baud_idx: 0,
+            status_message: String::new(),
+        }
     }
 }
 
 impl SettingsPanel {
-    pub fn show(&mut self, ui: &mut Ui, _state: &mut EmulatorState) {
+    pub fn show(
+        &mut self,
+        ui: &mut Ui,
+        serial_handle: &mut Option<SerialHandle>,
+        emulator_state: &Arc<Mutex<EmulatorState>>,
+        tokio_handle: &tokio::runtime::Handle,
+    ) {
         ui.heading("Emulator Settings");
         ui.separator();
 
         // Virtual printer management
         ui.group(|ui| {
             ui.label("Virtual Printer Management");
-            ui.label("Installs the emulator as a system printer");
-            
+            ui.label("Installs the emulator as a system printer (TCP port 9100)");
+
             ui.horizontal(|ui| {
                 if ui.button("🖨️ Install Windows Printer").clicked() {
                     self.install_windows_printer();
                 }
-                
+
                 if ui.button("🐧 Install Linux Printer").clicked() {
                     self.install_linux_printer();
                 }
-                
+
                 if ui.button("🗑️ Uninstall Printer").clicked() {
                     self.uninstall_printer();
                 }
             });
 
             ui.label("Note: Requires administrator privileges");
-            
-            // Check printer status
+
             if ui.button("🔍 Check Status").clicked() {
                 self.check_printer_status();
             }
@@ -46,12 +64,115 @@ impl SettingsPanel {
 
         ui.separator();
 
+        // Serial / COM port section
+        ui.group(|ui| {
+            ui.label("Serial / COM Port (USB Virtual)");
+            ui.label("Receives ESC/POS data via a virtual COM port pair (com0com)");
+
+            let is_running = serial_handle.as_ref().map(|h| h.is_running()).unwrap_or(false);
+
+            // Port selection row
+            ui.horizontal(|ui| {
+                ui.label("Port:");
+
+                let selected_text = self
+                    .available_ports
+                    .get(self.selected_port_idx)
+                    .cloned()
+                    .unwrap_or_else(|| "No ports found".to_string());
+
+                egui::ComboBox::from_id_source("com_port_select")
+                    .selected_text(&selected_text)
+                    .show_ui(ui, |ui| {
+                        for (i, port) in self.available_ports.iter().enumerate() {
+                            ui.selectable_value(&mut self.selected_port_idx, i, port);
+                        }
+                    });
+
+                if ui.button("🔄").on_hover_text("Refresh available ports").clicked() {
+                    self.available_ports = list_com_ports();
+                    self.selected_port_idx = 0;
+                }
+            });
+
+            // Baud rate row
+            ui.horizontal(|ui| {
+                ui.label("Baud:");
+                let selected_baud = self.baud_rates[self.selected_baud_idx];
+                egui::ComboBox::from_id_source("baud_rate_select")
+                    .selected_text(selected_baud.to_string())
+                    .show_ui(ui, |ui| {
+                        for (i, baud) in self.baud_rates.iter().enumerate() {
+                            ui.selectable_value(&mut self.selected_baud_idx, i, baud.to_string());
+                        }
+                    });
+            });
+
+            // Start / Stop row
+            ui.horizontal(|ui| {
+                if is_running {
+                    if ui.button("⏹ Stop").clicked() {
+                        if let Some(h) = serial_handle.take() {
+                            h.stop();
+                        }
+                        self.status_message = "Serial listener stopped.".to_string();
+                    }
+                    ui.colored_label(egui::Color32::GREEN, "● Running");
+                } else {
+                    let can_start = !self.available_ports.is_empty();
+                    if ui
+                        .add_enabled(can_start, egui::Button::new("▶ Start COM Listener"))
+                        .clicked()
+                    {
+                        let port = self.available_ports[self.selected_port_idx].clone();
+                        let baud = self.baud_rates[self.selected_baud_idx];
+                        match start_serial_listener(
+                            port.clone(),
+                            baud,
+                            emulator_state.clone(),
+                            tokio_handle.clone(),
+                        ) {
+                            Ok(handle) => {
+                                *serial_handle = Some(handle);
+                                self.status_message =
+                                    format!("Listening on {} @ {} baud", port, baud);
+                            }
+                            Err(e) => {
+                                self.status_message = format!("Error: {}", e);
+                            }
+                        }
+                    }
+                    ui.colored_label(egui::Color32::RED, "● Stopped");
+                }
+            });
+
+            if !self.status_message.is_empty() {
+                ui.label(&self.status_message);
+            }
+
+            ui.separator();
+
+            ui.collapsing("com0com Setup Guide", |ui| {
+                ui.label("com0com creates a virtual COM port pair on Windows.");
+                ui.label("One port is used by your PDV, the other by this emulator.");
+                ui.label("");
+                ui.label("1. Download: sourceforge.net/projects/com0com");
+                ui.label("2. Install com0com (run as administrator)");
+                ui.label("3. Open com0com Setup and create a pair (e.g. COM3 <-> COM4)");
+                ui.label("4. Configure your PDV/POS to send to COM3");
+                ui.label("5. Select COM4 in this emulator and click Start");
+                ui.label("");
+                ui.label("All data sent to COM3 will appear as a receipt here in real time.");
+            });
+        });
+
+        ui.separator();
+
         // Network settings
         ui.group(|ui| {
             ui.label("Network Configuration");
-            ui.label("TCP Port: 9100");
-            ui.label("Address: 127.0.0.1");
-            
+            ui.label("TCP Port: 9100  |  Address: 127.0.0.1");
+
             if ui.button("📡 Test Connection").clicked() {
                 self.test_network_connection();
             }
@@ -59,7 +180,6 @@ impl SettingsPanel {
 
         ui.separator();
 
-        // Information about operation
         ui.group(|ui| {
             ui.label("ℹ️  Automatic Operation");
             ui.label("• The emulator automatically respects ESC/POS standards");
@@ -70,7 +190,6 @@ impl SettingsPanel {
     }
 
     fn install_windows_printer(&self) {
-        // Simplified PowerShell command to avoid syntax errors
         let output = Command::new("powershell")
             .args([
                 "-Command",
@@ -84,130 +203,98 @@ impl SettingsPanel {
         match output {
             Ok(output) => {
                 if output.status.success() {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    println!("✅ {}", stdout);
+                    println!("✅ {}", String::from_utf8_lossy(&output.stdout));
                 } else {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    println!("❌ Error: {}", stderr);
+                    println!("❌ Error: {}", String::from_utf8_lossy(&output.stderr));
                 }
             }
-            Err(e) => {
-                println!("❌ Cannot execute printer installation: {}", e);
-            }
+            Err(e) => println!("❌ Cannot execute printer installation: {}", e),
         }
     }
 
     fn install_linux_printer(&self) {
-        // Install Linux printer using CUPS
         let output = Command::new("bash")
             .args([
                 "-c",
                 "if command -v lpstat &> /dev/null; then \
-                    echo 'Installing Linux printer...'; \
                     sudo lpadmin -p ESC_POS_Linux_Printer -E -v socket://127.0.0.1:9100 -m 'Generic Text-Only Printer'; \
                     sudo lpadmin -d ESC_POS_Linux_Printer; \
                     echo 'Linux printer installed successfully!'; \
                 else \
                     echo 'CUPS not found. Please install CUPS first.'; \
-                fi"
+                fi",
             ])
             .output();
 
         match output {
-            Ok(output) => {
-                if output.status.success() {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    println!("ℹ️  {}", stdout);
-                } else {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    println!("ℹ️  {}", stderr);
-                }
-            }
-            Err(e) => {
-                println!("ℹ️  Linux installation attempted: {}", e);
-            }
+            Ok(output) => println!("ℹ️  {}", String::from_utf8_lossy(&output.stdout)),
+            Err(e) => println!("ℹ️  Linux installation attempted: {}", e),
         }
     }
 
     fn uninstall_printer(&self) {
-        // Simplified PowerShell command
         let output = Command::new("powershell")
             .args([
                 "-Command",
                 "Remove-Printer -Name 'ESC_POS_Virtual_Printer' -Confirm:$false; \
                  Remove-PrinterPort -Name '127.0.0.1:9100'; \
-                 Write-Host 'Printer uninstalled successfully'"
+                 Write-Host 'Printer uninstalled successfully'",
             ])
             .output();
 
         match output {
             Ok(output) => {
                 if output.status.success() {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    println!("✅ {}", stdout);
+                    println!("✅ {}", String::from_utf8_lossy(&output.stdout));
                 } else {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    println!("❌ Error: {}", stderr);
+                    println!("❌ Error: {}", String::from_utf8_lossy(&output.stderr));
                 }
             }
-            Err(e) => {
-                println!("❌ Cannot execute printer uninstallation: {}", e);
-            }
+            Err(e) => println!("❌ Cannot execute printer uninstallation: {}", e),
         }
     }
 
     fn check_printer_status(&self) {
-        // Check if printer is installed
         let output = Command::new("powershell")
             .args([
                 "-Command",
-                "Get-Printer -Name 'ESC_POS_Virtual_Printer' -ErrorAction SilentlyContinue | Select-Object Name, PortName, DriverName, PrinterStatus"
+                "Get-Printer -Name 'ESC_POS_Virtual_Printer' -ErrorAction SilentlyContinue | Select-Object Name, PortName, DriverName, PrinterStatus",
             ])
             .output();
 
         match output {
-            Ok(output) => {
-                if output.status.success() {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    if stdout.trim().is_empty() {
-                        println!("ℹ️  Virtual printer not installed");
-                    } else {
-                        println!("✅ Virtual printer installed:");
-                        println!("{}", stdout);
-                    }
+            Ok(output) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                if stdout.trim().is_empty() {
+                    println!("ℹ️  Virtual printer not installed");
+                } else {
+                    println!("✅ Virtual printer installed:\n{}", stdout);
                 }
             }
-            Err(e) => {
-                println!("❌ Cannot check status: {}", e);
-            }
+            Ok(_) => println!("❌ Could not check printer status"),
+            Err(e) => println!("❌ Cannot check status: {}", e),
         }
     }
 
     fn test_network_connection(&self) {
-        // Test connection to port 9100
         let output = Command::new("powershell")
             .args([
                 "-Command",
-                "Test-NetConnection -ComputerName 127.0.0.1 -Port 9100 -WarningAction SilentlyContinue | Select-Object TcpTestSucceeded"
+                "Test-NetConnection -ComputerName 127.0.0.1 -Port 9100 -WarningAction SilentlyContinue | Select-Object TcpTestSucceeded",
             ])
             .output();
 
         match output {
-            Ok(output) => {
-                if output.status.success() {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    if stdout.contains("True") {
-                        println!("✅ Connection to port 9100 successful");
-                    } else {
-                        println!("❌ Connection to port 9100 failed");
-                    }
+            Ok(output) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                if stdout.contains("True") {
+                    println!("✅ Connection to port 9100 successful");
                 } else {
-                    println!("❌ Cannot test connection");
+                    println!("❌ Connection to port 9100 failed");
                 }
             }
-            Err(e) => {
-                println!("❌ Cannot test connection: {}", e);
-            }
+            Ok(_) => println!("❌ Cannot test connection"),
+            Err(e) => println!("❌ Cannot test connection: {}", e),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,17 +7,14 @@ use tracing::{info, Level};
 
 #[tokio::main]
 async fn main() -> Result<(), eframe::Error> {
-    // Initialize logging
     tracing_subscriber::fmt()
         .with_max_level(Level::INFO)
         .init();
 
     info!("🚀 Starting ESC/POS Emulator...");
 
-    // Create shared emulator state
     let emulator_state = Arc::new(Mutex::new(EmulatorState::new()));
 
-    // Start network server in background
     let server_state = emulator_state.clone();
     tokio::spawn(async move {
         if let Err(e) = server::start_server(server_state).await {
@@ -25,14 +22,15 @@ async fn main() -> Result<(), eframe::Error> {
         }
     });
 
+    let tokio_handle = tokio::runtime::Handle::current();
+
     info!("✅ Emulator initialized successfully");
 
-    // Launch GUI
     let options = eframe::NativeOptions::default();
 
     eframe::run_native(
         "ESC/POS Virtual Printer Emulator",
         options,
-        Box::new(|_cc| Box::new(EscPosEmulatorApp::new(emulator_state))),
+        Box::new(move |_cc| Box::new(EscPosEmulatorApp::new(emulator_state, tokio_handle))),
     )
 }

--- a/src/networking/mod.rs
+++ b/src/networking/mod.rs
@@ -1,3 +1,4 @@
 pub mod server;
+pub mod serial;
 
 pub use server::*;

--- a/src/networking/serial.rs
+++ b/src/networking/serial.rs
@@ -1,0 +1,98 @@
+use crate::emulator::EmulatorState;
+use crate::escpos::parser::EscPosParser;
+use anyhow::{Context, Result};
+use std::io::Read;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+pub struct SerialHandle {
+    running: Arc<AtomicBool>,
+}
+
+impl SerialHandle {
+    pub fn stop(&self) {
+        self.running.store(false, Ordering::SeqCst);
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.running.load(Ordering::SeqCst)
+    }
+}
+
+pub fn list_com_ports() -> Vec<String> {
+    match serialport::available_ports() {
+        Ok(ports) => ports.into_iter().map(|p| p.port_name).collect(),
+        Err(e) => {
+            warn!("Failed to list serial ports: {}", e);
+            Vec::new()
+        }
+    }
+}
+
+pub fn start_serial_listener(
+    port_name: String,
+    baud_rate: u32,
+    emulator_state: Arc<Mutex<EmulatorState>>,
+    tokio_handle: tokio::runtime::Handle,
+) -> Result<SerialHandle> {
+    let running = Arc::new(AtomicBool::new(true));
+    let running_clone = running.clone();
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
+
+    // Async task: receive bytes from channel, parse ESC/POS, process commands
+    tokio_handle.spawn(async move {
+        let mut parser = EscPosParser::new();
+        while let Some(data) = rx.recv().await {
+            match parser.parse_stream(&data) {
+                Ok(commands) => {
+                    let mut state = emulator_state.lock().await;
+                    for command in &commands {
+                        state.process_command(command);
+                    }
+                }
+                Err(e) => warn!("Serial parse error: {}", e),
+            }
+        }
+        info!("Serial data processor stopped");
+    });
+
+    // Open port synchronously so we can return an error immediately if it fails
+    let port = serialport::new(&port_name, baud_rate)
+        .timeout(Duration::from_millis(100))
+        .open()
+        .with_context(|| format!("Failed to open serial port {}", port_name))?;
+
+    // Sync thread: read bytes from serial port and forward to async channel
+    std::thread::spawn(move || {
+        let mut port = port;
+        let mut buf = vec![0u8; 1024];
+
+        while running_clone.load(Ordering::SeqCst) {
+            match port.read(&mut buf) {
+                Ok(0) => {}
+                Ok(n) => {
+                    if tx.send(buf[..n].to_vec()).is_err() {
+                        break; // receiver dropped
+                    }
+                }
+                Err(ref e)
+                    if e.kind() == std::io::ErrorKind::TimedOut
+                        || e.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(e) => {
+                    warn!("Serial read error: {}", e);
+                    break;
+                }
+            }
+        }
+
+        running_clone.store(false, Ordering::SeqCst);
+        info!("Serial listener stopped");
+    });
+
+    info!("Serial listener started on {} @ {} baud", port_name, baud_rate);
+    Ok(SerialHandle { running })
+}


### PR DESCRIPTION
## Summary
- Add `src/networking/serial.rs` with `SerialHandle`, `list_com_ports()`, and `start_serial_listener()` - sync read thread forwards bytes via channel to an async Tokio task that parses ESC/POS commands
- Add `serialport = 4` dependency to `Cargo.toml`
- Rework `SettingsPanel` with full COM port UI: port/baud ComboBoxes, Start/Stop buttons, running indicator, and com0com setup guide
- Pass `tokio::runtime::Handle` from `main` through `EscPosEmulatorApp` to the settings panel so the serial task runs on the existing runtime

## Why
Enables POS/PDV software to send ESC/POS data to the emulator over a virtual serial port (e.g. com0com pair on Windows), in addition to the existing TCP 9100 path.
